### PR TITLE
Add CASL compliance note to pilot form

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,8 +240,11 @@
           <input required id="consent" name="consent" type="checkbox" class="mt-1 text-brand-600" />
           <label for="consent" class="text-sm text-slate-600">I agree to receive pilot-related messages. Reply STOP to opt out.</label>
         </div>
-        <button class="w-full md:w-auto inline-flex justify-center items-center rounded-xl bg-brand-600 text-white px-6 py-3 font-semibold shadow-soft hover:bg-brand-700">Request my pilot</button>
-        <p class="text-sm text-slate-500">We’ll contact you within 24 hours. Prefer email? <a href="mailto:zakisandhu@hotmail.com" class="text-brand-600 hover:text-brand-700">zakisandhu@hotmail.com</a></p>
+        <div class="space-y-2">
+          <button class="w-full md:w-auto inline-flex justify-center items-center rounded-xl bg-brand-600 text-white px-6 py-3 font-semibold shadow-soft hover:bg-brand-700">Request my pilot</button>
+          <p class="text-xs text-slate-500">CASL-compliant. Opt-out anytime.</p>
+          <p class="text-sm text-slate-500">We’ll contact you within 24 hours. Prefer email? <a href="mailto:zakisandhu@hotmail.com" class="text-brand-600 hover:text-brand-700">zakisandhu@hotmail.com</a></p>
+        </div>
       </form>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add CASL compliance trust note below the pilot request button
- group the pilot call-to-action and support copy to keep spacing consistent across viewports

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dd66651400832ea944896341981a1f